### PR TITLE
Add support for repo_contents_cache

### DIFF
--- a/s3/private/BUILD.bazel
+++ b/s3/private/BUILD.bazel
@@ -24,6 +24,7 @@ bzl_library(
         "//docs:__pkg__",
         "//s3/private:__subpackages__",
     ],
+    deps = ["@bazel_tools//tools/build_defs/repo:utils.bzl"],
 )
 
 filegroup(


### PR DESCRIPTION
With this change, rules_s3 is compatible with `--experimental_remote_repo_contents_cache` and `--repo_contents_cache`. Files downloaded from S3 can now be stored in the contents cache iff `sha256` or `integrity` is set.